### PR TITLE
Use DNSClient instead of DNSSD

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,8 +34,8 @@ let package = Package(
         // LibP2P Core Modules
         .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMajor(from: "0.1.0")),
 
-        // DNS Support
-        .package(url: "https://github.com/Bouke/DNS.git", from: "1.0.0"),
+        // DNS + NIO
+        .package(url: "https://github.com/orlandos-nl/DNSClient.git", from: "2.4.4"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -44,7 +44,7 @@ let package = Package(
             name: "LibP2PDNSAddr",
             dependencies: [
                 .product(name: "LibP2P", package: "swift-libp2p"),
-                .product(name: "DNS", package: "DNS"),
+                .product(name: "DNSClient", package: "DNSClient"),
             ]
         ),
         .testTarget(

--- a/Sources/LibP2PDNSAddr/Application+DNSAddr.swift
+++ b/Sources/LibP2PDNSAddr/Application+DNSAddr.swift
@@ -18,7 +18,9 @@ extension Application.Resolvers.Provider {
     public static var dnsaddr: Self {
         .init { app in
             app.resolvers.use {
-                DNSAddr(application: $0)
+                let dnsAddr = DNSAddr(application: $0)
+                app.lifecycle.use(dnsAddr)
+                return dnsAddr
             }
         }
     }

--- a/Sources/LibP2PDNSAddr/Application+DNSAddr.swift
+++ b/Sources/LibP2PDNSAddr/Application+DNSAddr.swift
@@ -24,4 +24,14 @@ extension Application.Resolvers.Provider {
             }
         }
     }
+
+    public static func dnsaddr(host: SocketAddress) -> Self {
+        .init { app in
+            app.resolvers.use {
+                let dnsAddr = DNSAddr(application: $0, host: host)
+                app.lifecycle.use(dnsAddr)
+                return dnsAddr
+            }
+        }
+    }
 }

--- a/Sources/LibP2PDNSAddr/LibP2PDNSAddr.swift
+++ b/Sources/LibP2PDNSAddr/LibP2PDNSAddr.swift
@@ -12,19 +12,25 @@
 //
 //===----------------------------------------------------------------------===//
 
+import DNSClient
 import LibP2P
 
-#if canImport(dnssd)
-import dnssd
-#endif
+/// - Info: https://github.com/multiformats/multiaddr/blob/master/protocols/DNSADDR.md
+public final class DNSAddr: AddressResolver, LifecycleHandler {
 
-public final class DNSAddr: AddressResolver {
     public static var key: String = "DNSADDR"
+
+    public enum Errors: Error {
+        case clientNotInitialized
+        case invalidMultiaddr
+        case noMatchingHostFound
+    }
 
     private weak var application: Application!
     private var eventLoop: EventLoop
     private var logger: Logger
     private let uuid: UUID
+    private var client: DNSClient? = nil
 
     init(application: Application) {
         self.application = application
@@ -35,183 +41,129 @@ public final class DNSAddr: AddressResolver {
         self.logger[metadataKey: DNSAddr.key] = .string("[\(uuid.uuidString.prefix(5))]")
     }
 
-    /// Attempts to resovle a DNSADDR record
-    public func resolve(multiaddr: Multiaddr) -> [Multiaddr]? {
-        DNSAddr.resolve(address: multiaddr)
+    public func willBoot(_ application: Application) throws {
+        self.logger.trace("\(DNSAddr.key)::DNSClient Initializing")
+        self.client = try DNSClient.connect(on: self.eventLoop.next()).wait()
     }
 
-    public func resolve(multiaddr: Multiaddr, for codecs: Set<MultiaddrProtocol> = [.ip4, .tcp]) -> Multiaddr? {
-        DNSAddr.resolve(address: multiaddr, for: codecs)
-    }
-
-    public func resolve(multiaddr: Multiaddr) -> EventLoopFuture<[Multiaddr]?> {
-        self.eventLoop.submit { DNSAddr.resolve(address: multiaddr) }
-    }
-
-    public func resolve(
-        multiaddr: Multiaddr,
-        for codecs: Set<MultiaddrProtocol> = [.ip4, .tcp]
-    ) -> EventLoopFuture<Multiaddr?> {
-        self.eventLoop.submit { DNSAddr.resolve(address: multiaddr, for: codecs) }
+    public func shutdown(_ application: Application) {
+        self.logger.trace("\(DNSAddr.key)::DNSClient Shutdown")
+        self.client?.cancelQueries()
     }
 
     /// Provided a Multiaddr that uses the `dnsaddr` codec, this method will attempt to resolve the domain into it's underyling ip address.
     /// - Note: this method is not recusrive, it will only resolve `dnsaddr`s that are at most 2 layers deep.
-    /// - Info: https://github.com/multiformats/multiaddr/blob/master/protocols/DNSADDR.md
-    static func resolve(
-        address ma: Multiaddr,
-        for codecs: Set<MultiaddrProtocol> = [.ip4, .tcp],
-        callback: @escaping (Multiaddr?) -> Void
-    ) {
-        callback(resolve(address: ma, for: codecs))
-    }
-
-    static func resolve(address ma: Multiaddr, for codecs: Set<MultiaddrProtocol> = [.ip4, .tcp]) -> Multiaddr? {
-        guard let addresses = DNSAddr.resolve(address: ma) else { return nil }
-
-        return addresses.first(where: { addy in
-            Set(addy.addresses.map { $0.codec }).isSuperset(of: codecs)
-        })
-    }
-
-    static func resolve(address ma: Multiaddr) -> [Multiaddr]? {
-        #if !canImport(dnssd)
-        print("LibP2PDNSAddr is not supported on non darwin machines yet")
-        return nil
-        #else
-        /// Only proceed if the Mutliaddr is a dnsaddr proto and has a p2p peerID present
-        guard ma.addresses.first?.codec == .dnsaddr, let domain = ma.addresses.first?.addr, let pid = ma.getPeerID()
-        else {
-            return nil
-        }
-        let dnsAddrPrefix = "_dnsaddr."
-
-        let firstResolution = query(domainName: dnsAddrPrefix + domain)
-
-        /// This might resolve to a few different Multiaddr, but if we cant find a MA with the same peerID we bail...
-        guard
-            let host = firstResolution?.first(where: { key, val in
-                key.contains(pid)
+    public func resolve(
+        multiaddr: Multiaddr,
+        for codecs: Set<MultiaddrProtocol> = [.ip4, .tcp]
+    ) -> EventLoopFuture<Multiaddr?> {
+        self.resolve(multiaddr: multiaddr).map { addresses -> Multiaddr? in
+            guard let addresses else { return nil }
+            return addresses.first(where: { addy in
+                Set(addy.addresses.map { $0.codec }).isSuperset(of: codecs)
             })
-        else {
-            print("Error: Failed to find host during first round of DNS TXT Resolution")
-            //print("PeerID: \(pid)")
-            //print(firstResolution)
-            return nil
         }
-
-        guard let hostMA = try? Multiaddr(host.key) else {
-            print("Error: Failed to instantiated Multiaddress from dnsaddr text record.")
-            return nil
-        }
-
-        /// If the resolved address is another dnsaddr, attempt to resolve it...
-        guard hostMA.addresses.first?.codec == .dnsaddr, let domain2 = hostMA.addresses.first?.addr,
-            let pid2 = hostMA.getPeerID(), pid == pid2
-        else {
-            return [hostMA]
-        }
-
-        //print("Attempting to resolve `\(dnsAddrPrefix + domain2)`")
-        let secondResolution = query(domainName: dnsAddrPrefix + domain2)
-        //print(secondResolution)
-
-        let addresses = secondResolution?.compactMap({ key, val -> Multiaddr? in
-            /// Ensure its a valid multiaddr
-            guard let ma = try? Multiaddr(key) else { return nil }
-            /// Ensure the PeerID is present and equals that of the original multiaddr
-            guard ma.getPeerID() == pid else { return nil }
-            /// return the multiaddr
-            return ma
-        })
-
-        if let addresses = addresses, !addresses.isEmpty {
-            return addresses
-        } else {
-            return nil
-        }
-        #endif
     }
 
-    //private func fetchTextRecords(_ ma:Multiaddr)
+    /// Provided a Multiaddr that uses the `dnsaddr` codec, this method will attempt to resolve the domain into it's underyling ip addresses.
+    /// - Note: this method is not recusrive, it will only resolve `dnsaddr`s that are at most 2 layers deep.
+    public func resolve(multiaddr ma: Multiaddr) -> EventLoopFuture<[Multiaddr]?> {
+        let promise = self.eventLoop.makePromise(of: [Multiaddr]?.self)
 
-    /// This method actually performs the DNS Text Record Query using the standard DNS library `dnssd`
-    /// - Note: The Key Value dictionary that this method returns is kinda backwards. Due to their being multiple of the same text records, `dnsaddr` in this case, we save the value as the unique key and the record type as the value.
-    /// - Instead of this: ["dnsaddr": "/ip4/147.75.109.213/udp/4001/quic/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"]
-    /// - We return this:  ["/ip4/147.75.109.213/udp/4001/quic/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN": "dnsaddr"]
-    /// - Note: I grabbed this code from this gist (https://gist.github.com/fikeminkel/a9c4bc4d0348527e8df3690e242038d3)
-    static func query(domainName: String) -> [String: String]? {
-        #if !canImport(dnssd)
-        print("LibP2PDNSAddr is not supported on non darwin machines yet")
-        return nil
-        #else
-        var result: [String: String] = [:]
-        var recordHandler: ([String: String]?) -> Void = {
-            (record) -> Void in
-            if record != nil {
-                for (k, v) in record! {
-                    result.updateValue(v, forKey: k)
+        self.eventLoop.execute {
+
+            // Only proceed if the Mutliaddr is a dnsaddr proto and has a p2p peerID present
+            guard ma.addresses.first?.codec == .dnsaddr, let domain = ma.addresses.first?.addr, let pid = ma.getPeerID()
+            else { return promise.fail(Errors.invalidMultiaddr) }
+
+            // Peform the first resolution
+            let dnsAddrPrefix = "_dnsaddr."
+            let _ = self.resolveTXTRecords(forHost: dnsAddrPrefix + domain).map { txtRecords in
+
+                var dict: [String: String] = [:]
+                for txtRecord in txtRecords {
+                    txtRecord.values.forEach { dict[$0.value] = $0.key }
+                }
+
+                // This might resolve to a few different Multiaddr, but if we cant find a MA with the same peerID we bail...
+                guard
+                    let host = dict.first(where: { $0.key.contains(pid) })?.key
+                else {
+                    print("Error: Failed to find host during first round of DNS TXT Resolution")
+                    return promise.fail(Errors.noMatchingHostFound)
+                }
+
+                guard let hostMA = try? Multiaddr(host) else {
+                    print("Error: Failed to instantiated Multiaddress from dnsaddr text record.")
+                    return promise.fail(Errors.invalidMultiaddr)
+                }
+
+                // If the resolved address is another dnsaddr, attempt to resolve it...
+                guard hostMA.addresses.first?.codec == .dnsaddr, let domain2 = hostMA.addresses.first?.addr,
+                    let pid2 = hostMA.getPeerID(), pid == pid2
+                else {
+                    return promise.succeed([hostMA])
+                }
+
+                //print("Attempting to resolve `\(dnsAddrPrefix + domain2)`")
+                let _ = self.resolveTXTRecords(forHost: dnsAddrPrefix + domain2).map { txtRecords2 in
+
+                    var dict2: [String: String] = [:]
+                    for txtRecord in txtRecords2 {
+                        txtRecord.values.forEach { dict2[$0.value] = $0.key }
+                    }
+
+                    let addresses = dict2.compactMap({ key, val -> Multiaddr? in
+                        // Ensure its a valid multiaddr
+                        guard let ma = try? Multiaddr(key) else { return nil }
+                        // Ensure the PeerID is present and equals that of the original multiaddr
+                        guard ma.getPeerID() == pid else { return nil }
+                        // return the multiaddr
+                        return ma
+                    })
+
+                    if !addresses.isEmpty {
+                        return promise.succeed(addresses)
+                    } else {
+                        return promise.fail(Errors.noMatchingHostFound)
+                    }
                 }
             }
         }
 
-        let callback: DNSServiceQueryRecordReply = {
-            (sdRef, flags, interfaceIndex, errorCode, fullname, rrtype, rrclass, rdlen, rdata, ttl, context) -> Void in
-            guard let handlerPtr = context?.assumingMemoryBound(to: (([String: String]?) -> Void).self) else {
-                return
-            }
-            let handler = handlerPtr.pointee
-            if errorCode != kDNSServiceErr_NoError {
-                return
-            }
-            guard let txtPtr = rdata?.assumingMemoryBound(to: UInt8.self) else {
-                return
-            }
-            let txt = String(cString: txtPtr.advanced(by: 1))
-            var record: [String: String] = [:]
-            let parts = txt.components(separatedBy: "=")
+        return promise.futureResult
+    }
 
-            record[parts[1]] = parts[0]
-
-            handler(record)
+    private func resolveTXTRecords(forHost host: String) -> EventLoopFuture<[TXTRecord]> {
+        self.client!.sendQuery(forHost: host, type: .txt).map { results -> [TXTRecord] in
+            var values: [TXTRecord] = []
+            for answer in results.answers {
+                switch answer {
+                case .txt(let txtRecord):
+                    values.append(txtRecord.resource)
+                default:
+                    continue
+                }
+            }
+            return values
         }
-
-        let serviceRef: UnsafeMutablePointer<DNSServiceRef?> = UnsafeMutablePointer.allocate(
-            capacity: MemoryLayout<DNSServiceRef>.size
-        )
-        let code = DNSServiceQueryRecord(
-            serviceRef,
-            kDNSServiceFlagsTimeout,
-            0,
-            domainName,
-            UInt16(kDNSServiceType_TXT),
-            UInt16(kDNSServiceClass_IN),
-            callback,
-            &recordHandler
-        )
-        if code != kDNSServiceErr_NoError {
-            return nil
-        }
-        DNSServiceProcessResult(serviceRef.pointee)
-        DNSServiceRefDeallocate(serviceRef.pointee)
-
-        return result
-        #endif
     }
 }
 
-extension Multiaddr {
-
-    public func resolve(for codecs: Set<MultiaddrProtocol> = [.ip4, .tcp]) -> Multiaddr? {
-        DNSAddr.resolve(address: self, for: codecs)
-    }
-
-    public func resolve(
-        address ma: Multiaddr,
-        for codecs: Set<MultiaddrProtocol> = [.ip4, .tcp],
-        callback: @escaping (Multiaddr?) -> Void
-    ) {
-        DNSAddr.resolve(address: self, for: codecs, callback: callback)
-    }
-
-}
+//extension Multiaddr {
+//
+//    public func resolve(for codecs: Set<MultiaddrProtocol> = [.ip4, .tcp]) -> Multiaddr? {
+//        nil
+//        //DNSAddr.resolve(address: self, for: codecs)
+//    }
+//
+//    public func resolve(
+//        address ma: Multiaddr,
+//        for codecs: Set<MultiaddrProtocol> = [.ip4, .tcp],
+//        callback: @escaping (Multiaddr?) -> Void
+//    ) {
+//        callback(nil)
+//        //DNSAddr.resolve(address: self, for: codecs, callback: callback)
+//    }
+//
+//}

--- a/Sources/LibP2PDNSAddr/LibP2PDNSAddr.swift
+++ b/Sources/LibP2PDNSAddr/LibP2PDNSAddr.swift
@@ -82,7 +82,9 @@ public final class DNSAddr: AddressResolver, LifecycleHandler {
 
                 var dict: [String: String] = [:]
                 for txtRecord in txtRecords {
-                    txtRecord.values.forEach { dict[$0.value] = $0.key }
+                    for entry in txtRecord.values {
+                        dict[entry.value] = entry.key
+                    }
                 }
 
                 // This might resolve to a few different Multiaddr, but if we cant find a MA with the same peerID we bail...
@@ -110,7 +112,9 @@ public final class DNSAddr: AddressResolver, LifecycleHandler {
 
                     var dict2: [String: String] = [:]
                     for txtRecord in txtRecords2 {
-                        txtRecord.values.forEach { dict2[$0.value] = $0.key }
+                        for entry in txtRecord.values {
+                            dict2[entry.value] = entry.key
+                        }
                     }
 
                     let addresses = dict2.compactMap({ key, val -> Multiaddr? in

--- a/Sources/LibP2PDNSAddr/LibP2PDNSAddr.swift
+++ b/Sources/LibP2PDNSAddr/LibP2PDNSAddr.swift
@@ -54,7 +54,8 @@ public final class DNSAddr: AddressResolver, LifecycleHandler {
     public func willBoot(_ application: Application) throws {
         self.logger.trace("Initializing")
         // We connect with TCP due to UDP packet size contstraints (UPD seems to max out at 4 records)
-        self.client = try DNSClient.connectTCP(on: self.eventLoop.next()).wait()
+        let googleDNS = try SocketAddress(ipAddress: "8.8.8.8", port: 53)
+        self.client = try DNSClient.connectTCP(on: self.eventLoop.next(), config: [googleDNS]).wait()
     }
 
     public func shutdown(_ application: Application) {

--- a/Sources/LibP2PDNSAddr/LibP2PDNSAddr.swift
+++ b/Sources/LibP2PDNSAddr/LibP2PDNSAddr.swift
@@ -53,11 +53,12 @@ public final class DNSAddr: AddressResolver, LifecycleHandler {
 
     public func willBoot(_ application: Application) throws {
         self.logger.trace("Initializing")
-        self.client = try DNSClient.connect(on: self.eventLoop.next()).wait()
+        // We connect with TCP due to UDP packet size contstraints (UPD seems to max out at 4 records)
+        self.client = try DNSClient.connectTCP(on: self.eventLoop.next()).wait()
     }
 
     public func shutdown(_ application: Application) {
-        self.logger.trace("Shutdown")
+        self.logger.trace("Shutting Down")
         self.client?.cancelQueries()
     }
 

--- a/Tests/LibP2PDNSAddrTests/LibP2PDNSAddrTests.swift
+++ b/Tests/LibP2PDNSAddrTests/LibP2PDNSAddrTests.swift
@@ -51,7 +51,9 @@ final class LibP2PDNSAddrTests: XCTestCase {
 
         let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.ip4, .tcp]).wait()
 
-        XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
+        if let resolvedAddress {
+            XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
+        }
     }
 
     func testDNSADDRToMultiaddr_IPv4_UDP() throws {
@@ -61,7 +63,9 @@ final class LibP2PDNSAddrTests: XCTestCase {
 
         let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.ip4, .udp, .quic_v1]).wait()
 
-        XCTAssertEqual(resolvedAddress, try! Multiaddr(expectedAddress))
+        if let resolvedAddress {
+            XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
+        }
     }
 
     func testDNSADDRToMultiaddr_IPv6_TCP() throws {
@@ -71,7 +75,9 @@ final class LibP2PDNSAddrTests: XCTestCase {
 
         let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.ip6, .tcp]).wait()
 
-        XCTAssertEqual(resolvedAddress, try! Multiaddr(expectedAddress))
+        if let resolvedAddress {
+            XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
+        }
     }
 
     func testDNSADDRToMultiaddr_IPv6_UDP() throws {
@@ -82,7 +88,9 @@ final class LibP2PDNSAddrTests: XCTestCase {
 
         let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.ip6, .udp, .quic_v1]).wait()
 
-        XCTAssertEqual(resolvedAddress, try! Multiaddr(expectedAddress))
+        if let resolvedAddress {
+            XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
+        }
     }
 
     func testDNSADDRToMultiaddr_DNS4_TCP_WSS() throws {
@@ -93,7 +101,9 @@ final class LibP2PDNSAddrTests: XCTestCase {
 
         let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.dns4, .tcp, .wss]).wait()
 
-        XCTAssertEqual(resolvedAddress, try! Multiaddr(expectedAddress))
+        if let resolvedAddress {
+            XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
+        }
     }
 
     func testDNSADDRToMultiaddr_DNS6_TCP_WSS() throws {
@@ -104,7 +114,9 @@ final class LibP2PDNSAddrTests: XCTestCase {
 
         let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.dns6, .tcp, .wss]).wait()
 
-        XCTAssertEqual(resolvedAddress, try! Multiaddr(expectedAddress))
+        if let resolvedAddress {
+            XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
+        }
     }
 
 }

--- a/Tests/LibP2PDNSAddrTests/LibP2PDNSAddrTests.swift
+++ b/Tests/LibP2PDNSAddrTests/LibP2PDNSAddrTests.swift
@@ -51,9 +51,7 @@ final class LibP2PDNSAddrTests: XCTestCase {
 
         let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.ip4, .tcp]).wait()
 
-        if let resolvedAddress {
-            XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
-        }
+        XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
     }
 
     func testDNSADDRToMultiaddr_IPv4_UDP() throws {
@@ -63,9 +61,7 @@ final class LibP2PDNSAddrTests: XCTestCase {
 
         let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.ip4, .udp, .quic_v1]).wait()
 
-        if let resolvedAddress {
-            XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
-        }
+        XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
     }
 
     func testDNSADDRToMultiaddr_IPv6_TCP() throws {
@@ -75,9 +71,7 @@ final class LibP2PDNSAddrTests: XCTestCase {
 
         let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.ip6, .tcp]).wait()
 
-        if let resolvedAddress {
-            XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
-        }
+        XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
     }
 
     func testDNSADDRToMultiaddr_IPv6_UDP() throws {
@@ -88,9 +82,7 @@ final class LibP2PDNSAddrTests: XCTestCase {
 
         let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.ip6, .udp, .quic_v1]).wait()
 
-        if let resolvedAddress {
-            XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
-        }
+        XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
     }
 
     func testDNSADDRToMultiaddr_DNS4_TCP_WSS() throws {
@@ -101,9 +93,7 @@ final class LibP2PDNSAddrTests: XCTestCase {
 
         let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.dns4, .tcp, .wss]).wait()
 
-        if let resolvedAddress {
-            XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
-        }
+        XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
     }
 
     func testDNSADDRToMultiaddr_DNS6_TCP_WSS() throws {
@@ -114,8 +104,6 @@ final class LibP2PDNSAddrTests: XCTestCase {
 
         let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.dns6, .tcp, .wss]).wait()
 
-        if let resolvedAddress {
-            XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
-        }
+        XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
     }
 }

--- a/Tests/LibP2PDNSAddrTests/LibP2PDNSAddrTests.swift
+++ b/Tests/LibP2PDNSAddrTests/LibP2PDNSAddrTests.swift
@@ -23,7 +23,10 @@ final class LibP2PDNSAddrTests: XCTestCase {
 
     override func setUpWithError() throws {
         app = try Application(.detect())
-        app.resolvers.use(.dnsaddr)
+        // On some github workers, the default dns provider locks.
+        // We can fix this by hardcoding a resolver (such as cloudflare or google)
+        let cloudflareDNS = try SocketAddress(ipAddress: "1.1.1.1", port: 53)
+        app.resolvers.use(.dnsaddr(host: cloudflareDNS))
         try app.start()
     }
 

--- a/Tests/LibP2PDNSAddrTests/LibP2PDNSAddrTests.swift
+++ b/Tests/LibP2PDNSAddrTests/LibP2PDNSAddrTests.swift
@@ -118,5 +118,4 @@ final class LibP2PDNSAddrTests: XCTestCase {
             XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
         }
     }
-
 }

--- a/Tests/LibP2PDNSAddrTests/LibP2PDNSAddrTests.swift
+++ b/Tests/LibP2PDNSAddrTests/LibP2PDNSAddrTests.swift
@@ -12,37 +12,36 @@
 //
 //===----------------------------------------------------------------------===//
 
-import DNS
+import DNSClient
 import LibP2P
 import XCTest
 
 @testable import LibP2PDNSAddr
 
 final class LibP2PDNSAddrTests: XCTestCase {
-    #if canImport(dnssd)
-    func testDNSTextRecordQuery() throws {
-        let firstResolution = DNSAddr.query(domainName: "_dnsaddr.bootstrap.libp2p.io")
-        print(firstResolution ?? "NIL")
-        XCTAssertGreaterThan(firstResolution!.count, 0)
+    var app: Application!
 
-        print("Resolving Next...")
-        guard
-            let host = firstResolution?.first(where: { key, val in
-                key.contains("QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN")
-            })
-        else {
-            XCTFail("Failed to find host during first round of DNS TXT Resolution")
+    override func setUpWithError() throws {
+        app = try Application(.detect())
+        app.resolvers.use(.dnsaddr)
+        try app.start()
+    }
+
+    override func tearDownWithError() throws {
+        app.shutdown()
+    }
+
+    func testDNSADDRToMultiaddr() throws {
+
+        let address = "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
+
+        let resolvedAddresses = try app.resolve(try Multiaddr(address)).wait()
+
+        guard let resolvedAddresses else {
+            XCTFail("No Resolved Multiaddr")
             return
         }
-
-        guard let hostMA = try? Multiaddr(host.key) else {
-            XCTFail("Failed to instantiated Multiaddress from dnsaddr text record.")
-            return
-        }
-
-        print("Attempting to resolve `\("_dnsaddr.\(hostMA.addresses.first!.addr!)")`")
-        let secondResolution = DNSAddr.query(domainName: "_dnsaddr.\(hostMA.addresses.first!.addr!)")
-        print(secondResolution ?? "NIL")
+        XCTAssertGreaterThan(resolvedAddresses.count, 0)
     }
 
     func testDNSADDRToMultiaddr_IPv4_TCP() throws {
@@ -50,9 +49,9 @@ final class LibP2PDNSAddrTests: XCTestCase {
         let address = "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
         let expectedAddress = "/ip4/139.178.91.71/tcp/4001/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
 
-        let resolvedAddress = DNSAddr.resolve(address: try! Multiaddr(address), for: [.ip4, .tcp])
+        let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.ip4, .tcp]).wait()
 
-        XCTAssertEqual(resolvedAddress, try! Multiaddr(expectedAddress))
+        XCTAssertEqual(resolvedAddress, try Multiaddr(expectedAddress))
     }
 
     func testDNSADDRToMultiaddr_IPv4_UDP() throws {
@@ -60,7 +59,7 @@ final class LibP2PDNSAddrTests: XCTestCase {
         let address = "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
         let expectedAddress = "/ip4/139.178.91.71/udp/4001/quic-v1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
 
-        let resolvedAddress = DNSAddr.resolve(address: try! Multiaddr(address), for: [.ip4, .udp, .quic_v1])
+        let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.ip4, .udp, .quic_v1]).wait()
 
         XCTAssertEqual(resolvedAddress, try! Multiaddr(expectedAddress))
     }
@@ -70,7 +69,7 @@ final class LibP2PDNSAddrTests: XCTestCase {
         let address = "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
         let expectedAddress = "/ip6/2604:1380:45e3:6e00::1/tcp/4001/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
 
-        let resolvedAddress = DNSAddr.resolve(address: try! Multiaddr(address), for: [.ip6, .tcp])
+        let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.ip6, .tcp]).wait()
 
         XCTAssertEqual(resolvedAddress, try! Multiaddr(expectedAddress))
     }
@@ -81,7 +80,7 @@ final class LibP2PDNSAddrTests: XCTestCase {
         let expectedAddress =
             "/ip6/2604:1380:45e3:6e00::1/udp/4001/quic-v1/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
 
-        let resolvedAddress = DNSAddr.resolve(address: try! Multiaddr(address), for: [.ip6, .udp, .quic_v1])
+        let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.ip6, .udp, .quic_v1]).wait()
 
         XCTAssertEqual(resolvedAddress, try! Multiaddr(expectedAddress))
     }
@@ -92,7 +91,7 @@ final class LibP2PDNSAddrTests: XCTestCase {
         let expectedAddress =
             "/dns4/sv15.bootstrap.libp2p.io/tcp/443/wss/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
 
-        let resolvedAddress = DNSAddr.resolve(address: try! Multiaddr(address), for: [.dns4, .tcp, .wss])
+        let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.dns4, .tcp, .wss]).wait()
 
         XCTAssertEqual(resolvedAddress, try! Multiaddr(expectedAddress))
     }
@@ -103,9 +102,9 @@ final class LibP2PDNSAddrTests: XCTestCase {
         let expectedAddress =
             "/dns6/sv15.bootstrap.libp2p.io/tcp/443/wss/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN"
 
-        let resolvedAddress = DNSAddr.resolve(address: try! Multiaddr(address), for: [.dns6, .tcp, .wss])
+        let resolvedAddress = try app.resolve(try Multiaddr(address), for: [.dns6, .tcp, .wss]).wait()
 
         XCTAssertEqual(resolvedAddress, try! Multiaddr(expectedAddress))
     }
-    #endif
+
 }


### PR DESCRIPTION
### What: 
- This PR replaces dnssd with [DNSClient](https://github.com/orlandos-nl/DNSClient)

### Changes:
- Removed all static methods
- Removed all synchronous methods
- `DNSADDR` hooks into `LifecycleHandler` now to support set up and teardown of the `DNSClient`  
- Solves the deadlock issue we were experiencing with `dnssd` in GitHub actions / workflow tests
- Added the ability to explicitly set your dns resolver via
```swift
// Uses the hosts machines default resolver
app.resolvers.use(.dnsaddr)

// Or explicitly set a resolver of your choice
let cloudflareDNS = try SocketAddress(ipAddress: "1.1.1.1", port: 53)
app.resolvers.use(.dnsaddr(host: cloudflareDNS))
```

### Fixes:
- #1