### PR TITLE
Multiaddr Update

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,10 +32,10 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
 
         // LibP2P Core Modules
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMajor(from: "0.1.0")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMinor(from: "0.2.0")),
 
         // DNS + NIO
-        .package(url: "https://github.com/orlandos-nl/DNSClient.git", from: "2.4.4"),
+        .package(url: "https://github.com/orlandos-nl/DNSClient.git", .upToNextMajor(from: "2.4.4")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
### What:
- Updated `getPeerID` to support the latest `Multiaddr` release
https://github.com/swift-libp2p/swift-multiaddr/releases/tag/0.1.0

### Why:
- https://github.com/swift-libp2p/swift-multiaddr/issues/14

### Breaking Changes
```swift
// From
Multiaddr.getPeerID() -> String?

// To
Multiaddr.getPeerID() throws -> PeerID
```