### PR TITLE
App async init

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "swift-libp2p-dnsaddr",
     platforms: [
-        .macOS(.v10_15),
+        .macOS(.v13),
         .iOS(.v13),
     ],
     products: [
@@ -35,7 +35,7 @@ let package = Package(
         .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMinor(from: "0.3.3")),
 
         // DNS + NIO
-        .package(url: "https://github.com/orlandos-nl/DNSClient.git", .upToNextMajor(from: "2.4.4")),
+        .package(url: "https://github.com/orlandos-nl/DNSClient.git", .upToNextMajor(from: "2.6.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
 
         // LibP2P Core Modules
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMinor(from: "0.3.0")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMinor(from: "0.3.3")),
 
         // DNS + NIO
         .package(url: "https://github.com/orlandos-nl/DNSClient.git", .upToNextMajor(from: "2.4.4")),

--- a/Tests/LibP2PDNSAddrTests/LibP2PDNSAddrTests.swift
+++ b/Tests/LibP2PDNSAddrTests/LibP2PDNSAddrTests.swift
@@ -22,7 +22,7 @@ import Testing
 struct LibP2PDNSAddrTests {
 
     @Test func testAppConfiguration() async throws {
-        let app = try Application(.detect())
+        let app = try await Application.make(.detect(), peerID: .ephemeral())
         app.resolvers.use(.dnsaddr)
         try await app.startup()
         try await app.asyncShutdown()
@@ -35,7 +35,7 @@ final class LibP2PDNSAddrResolutionTests {
     var app: Application!
 
     init() async throws {
-        app = try Application(.detect())
+        app = try await Application.make(.detect(), peerID: .ephemeral())
         // On some github workers, the default dns provider locks.
         // We can fix this by hardcoding a resolver (such as cloudflare or google)
         let cloudflareDNS = try SocketAddress(ipAddress: "1.1.1.1", port: 53)

--- a/Tests/LibP2PDNSAddrTests/LibP2PDNSAddrTests.swift
+++ b/Tests/LibP2PDNSAddrTests/LibP2PDNSAddrTests.swift
@@ -34,13 +34,13 @@ struct LibP2PDNSAddrTests {
 final class LibP2PDNSAddrResolutionTests {
     var app: Application!
 
-    init() async throws {
-        app = try await Application.make(.detect(), peerID: .ephemeral())
+    init() throws {
+        app = try Application(.detect())
         // On some github workers, the default dns provider locks.
         // We can fix this by hardcoding a resolver (such as cloudflare or google)
         let cloudflareDNS = try SocketAddress(ipAddress: "1.1.1.1", port: 53)
         app.resolvers.use(.dnsaddr(host: cloudflareDNS))
-        try await app.startup()
+        try app.start()
     }
 
     deinit {


### PR DESCRIPTION
### What?
- move to the new async application initializer `Application.make(_ env: ...)` in our tests